### PR TITLE
[policy] Do not route to A2DP if call exists.

### DIFF
--- a/basic/policy/audio_route_rules.pl
+++ b/basic/policy/audio_route_rules.pl
@@ -150,8 +150,21 @@ invalid_audio_device_choice(ringtone, sink, Device) :-
 %
 % do not route cscall or ipcall to bta2dp
 %
-invalid_audio_device_choice(call, _, bta2dp).
-invalid_audio_device_choice(call, _, tvoutandbta2dp).
+invalid_audio_device_choice(_, _, bta2dp) :-
+    context:call_state(active) ;
+    context:call_state(incoming) ;
+    context:call_state(outgoing),!.
+
+invalid_audio_device_choice(_, _, tvoutandbta2dp) :-
+    context:call_state(active) ;
+    context:call_state(incoming) ;
+    context:call_state(outgoing),!.
+
+invalid_audio_device_choice(_, _, bta2dpforalien) :-
+    context:call_state(active) ;
+    context:call_state(incoming) ;
+    context:call_state(outgoing),!.
+
 %
 % do not route calls to regular bthsp
 %


### PR DESCRIPTION
Even if call resource class is not active, if call is in any state other
than inactive, do not route audio to A2DP. This way we can prevent audio
from leaking to A2DP when ringtone playing in incoming call state ends
before call state changes to active.
