### PR TITLE
Add mechanism to determine media state.

### DIFF
--- a/basic/policy/policy.dres
+++ b/basic/policy/policy.dres
@@ -250,9 +250,13 @@ $vibra_mute += { group: event, mute: unmuted }
 # backlight control
 $backlight   = { state: off }
 
+# currently active (topmost) application pid
+$active_application = { pid: 0 }
+
 # contexts
 $context   = { variable: call                   ,  value: inactive }
 $context   = { variable: bluetooth_override     ,  value: disabled }  # disabled - active - inactive
+$context   = { variable: media_state            ,  value: inactive }  # inactive - background - foreground - active
 #$context   = { variable: call_audio_type,  value: none     }
 #$context   = { variable: camera         ,  value: inactive }
 
@@ -497,11 +501,14 @@ telephony_sending_dialstring:
 # dialstring sending stopped
 telephony_stopped_dialstring:
 
+active_application_request:
+	$active_application:pid = &pid
 
 # context variables:
 # call                  - com.nokia.policy.call ($call) changes
 # bluetooth_override    - com.nokia.policy.bluetooth_override ($bluetooth_override) changes
-context: $call $bluetooth_override
+# media_state           - com.nokia.policy.media_state
+context: $bluetooth_override $active_application $resource_set
 	$context[variable] |= prolog(update_contexts)
 
 # block resolving if any policy plugin is not ready

--- a/basic/policy/resource.pl
+++ b/basic/policy/resource.pl
@@ -2,7 +2,8 @@
 	  [update_resource_entries/1, update_resource_owner_entries/1,
 	   resource_owner/2, resource_owner/3, resource_group/2,
  	   granted_resource/2, granted_resource/3, active_resource/3,
-	   force_resource_release/3, resource_class_request/4]).
+	   force_resource_release/3, resource_class_request/4,
+	   resource_set_pid_registered/2, resource_set_pid_granted/2]).
 
 rules([update_resource_entries/1, update_resource_owner_entries/1,
        force_resource_release/3, resource_class_request/4]).
@@ -406,6 +407,22 @@ resource_set_with_active_audio(ManagerId, Class, AudioGroup) :-
 		[ManagerId , Class, acquire, 0    , Granted, AudioGroup]),
     resource_class(Class),
     resource_bit(audio_playback, ResourceBit),
+    GrantedBit is Granted /\ ResourceBit,
+    GrantedBit = ResourceBit.
+
+resource_set_pid_registered(ClientPid, Resource) :-
+    fact_exists('com.nokia.policy.resource_set',
+        [client_pid, mandatory],
+        [ClientPid,  Mandatory]),
+    resource_bit(Resource, ResourceBit),
+    WantedBit is Mandatory /\ ResourceBit,
+    WantedBit = ResourceBit.
+
+resource_set_pid_granted(ClientPid, Resource) :-
+    fact_exists('com.nokia.policy.resource_set',
+        [client_pid, granted],
+        [ClientPid,  Granted]),
+    resource_bit(Resource, ResourceBit),
     GrantedBit is Granted /\ ResourceBit,
     GrantedBit = ResourceBit.
 


### PR DESCRIPTION
Add new dres target topmost_pid. This target can be used to tell OHM
about the topmost application. OHM then maps this information against
currently registered resource policy clients with audio_playback
resource.

| system state | media state |
| --- | --- |
| call in any state | inactive |
|  |  |
| no resource clients with audio_playback | inactive |
|  |  |
| resources are granted and | active |
| topmpost PID == resource client PID |  |
|  |  |
| resources are granted and | background |
| topmost PID != resource client PID |  |
|  |  |
| resources are not granted and | foreground |
| topmost PID == resource client PID |  |

Media state information is passed as context value "media_state".
