### PR TITLE
Release resources from other players when new one acquires. 

### DIFF
--- a/basic/policy/policy.dres
+++ b/basic/policy/policy.dres
@@ -30,6 +30,8 @@ $resource_owner += {resource: audio_playback , owner: nobody, mode: shared, \
                     group   : nobody }
 
 $audio_resource_owner = { previous: nobody, current: nobody }
+$active_audio_manager_id = { id: 0 }
+$active_audio_manager = { previous: 0, current: 0 }
 $call_start_privacy = { value: none }
 
 $resource_set = {manager_id:0,  client_name:dres, client_id:0, class:fake,    \
@@ -393,9 +395,28 @@ backlight_actions: $backlight
 resource_request:
 	echo('*** resource_request: ', &request, ' ', &manager_id)
 	$audio_resource_owner:previous = $resource_owner[resource:audio_playback]:owner
+	$active_audio_manager_id = prolog(get_active_audio_manager_id)
+	$active_audio_manager:previous = $active_audio_manager_id:id
+	#echo('$active_audio_manager:previous changes to ', $active_audio_manager:previous)
 	$resource_set[manager_id] |= prolog(update_resource_entries)
 	$resource_owner[resource] |= prolog(update_resource_owner_entries)
 	$audio_resource_owner:current = $resource_owner[resource:audio_playback]:owner
+	$active_audio_manager_id = prolog(get_active_audio_manager_id)
+	$active_audio_manager:current = $active_audio_manager_id:id
+	#echo('$active_audio_manager:current changes to ', $active_audio_manager:current)
+
+	# If active manager_id changes release the previous active playback, so that when the
+	# new player pauses, previously active playback won't continue.
+	if $active_audio_manager:previous != 0 &&                           \
+	   $active_audio_manager:current != 0 &&                            \
+	   $audio_resource_owner:previous != 'call' &&                      \
+	   $audio_resource_owner:current != 'call' &&                       \
+	   $active_audio_manager:previous != $active_audio_manager:current  \
+	   then
+	    #echo('*** force_resource_release_one ', $active_audio_manager:previous)
+	    $resource_set[manager_id] |= prolog(force_resource_release_one, $active_audio_manager:previous)
+	end
+
 	resolve(all)
 
 

--- a/basic/policy/resource.pl
+++ b/basic/policy/resource.pl
@@ -1,12 +1,14 @@
 :- module(resource,
-	  [update_resource_entries/1, update_resource_owner_entries/1,
-	   resource_owner/2, resource_owner/3, resource_group/2,
- 	   granted_resource/2, granted_resource/3, active_resource/3,
-	   force_resource_release/3, resource_class_request/4,
-	   resource_set_pid_registered/2, resource_set_pid_granted/2]).
+         [update_resource_entries/1, update_resource_owner_entries/1,
+          resource_owner/2, resource_owner/3, resource_group/2,
+          granted_resource/2, granted_resource/3, active_resource/3,
+          force_resource_release/3, resource_class_request/4,
+          resource_set_pid_registered/2, resource_set_pid_granted/2,
+          force_resource_release_one/2, get_active_audio_manager_id/1]).
 
 rules([update_resource_entries/1, update_resource_owner_entries/1,
-       force_resource_release/3, resource_class_request/4]).
+       force_resource_release/3, resource_class_request/4,
+       force_resource_release_one/2, get_active_audio_manager_id/1]).
 
 
 /*
@@ -409,6 +411,20 @@ resource_set_with_active_audio(ManagerId, Class, AudioGroup) :-
     resource_bit(audio_playback, ResourceBit),
     GrantedBit is Granted /\ ResourceBit,
     GrantedBit = ResourceBit.
+
+get_active_audio_manager_id(ActionList) :-
+    resource_set_with_active_audio(ManagerId, _, _) *->
+        ActionList = [[ active_audio_manager_id, [ id, ManagerId ] ]]
+    ;
+        ActionList = [[ active_audio_manager_id, [ id, 0 ] ]].
+
+block_entry_one(ManagerId, Entry) :-
+    Entry = [resource_set, [manager_id, ManagerId], [block, 1]].
+
+force_resource_release_one(ManagerId, List) :-
+    findall(E, block_entry_one(ManagerId, E), List), !
+    ;
+    List = [].
 
 resource_set_pid_registered(ClientPid, Resource) :-
     fact_exists('com.nokia.policy.resource_set',


### PR DESCRIPTION
Currently when new same-class client acquires the resources, others stay
and wait for the resources to be freed. This can cause unwanted side
effects.

This commit changes the behavior so that when new same-class client
acquires the resources, other clients' resources are force-released.
