### PR TITLE
Match alien application id with active id.

### DIFF
--- a/basic/policy/policy.dres
+++ b/basic/policy/policy.dres
@@ -264,6 +264,8 @@ $backlight   = { state: off }
 
 # currently active (topmost) application pid
 $active_application = { pid: 0 }
+# alien UI process id
+$alien_application = { pid: -1 }
 
 # contexts
 $context   = { variable: call                   ,  value: inactive }
@@ -535,11 +537,14 @@ telephony_stopped_dialstring:
 active_application_request:
 	$active_application:pid = &pid
 
+alien_application_request:
+	$alien_application:pid = &pid
+
 # context variables:
 # call                  - com.nokia.policy.call ($call) changes
 # bluetooth_override    - com.nokia.policy.bluetooth_override ($bluetooth_override) changes
 # media_state           - com.nokia.policy.media_state
-context: $bluetooth_override $active_application $resource_set
+context: $bluetooth_override $active_application $alien_application $resource_set
 	$context[variable] |= prolog(update_contexts)
 
 # block resolving if any policy plugin is not ready

--- a/basic/policy/policy.dres
+++ b/basic/policy/policy.dres
@@ -405,7 +405,7 @@ backlight_actions: $backlight
 		       'com.nokia.policy.backlight')
 
 resource_request:
-	echo('*** resource_request: ', &request, ' ', &manager_id)
+	#echo('*** resource_request: ', &request, ' ', &manager_id)
 	$audio_resource_owner:previous = $resource_owner[resource:audio_playback]:owner
 	$active_audio_manager_id = prolog(get_active_audio_manager_id)
 	$active_audio_manager:previous = $active_audio_manager_id:id


### PR DESCRIPTION
Add dres target for specifying alien UI process id. This process id is
then used to determine more exact media state.
