### PR TITLE
Revert "Don't spam resource requests to log."

### DIFF
--- a/basic/policy/policy.dres
+++ b/basic/policy/policy.dres
@@ -405,7 +405,7 @@ backlight_actions: $backlight
 		       'com.nokia.policy.backlight')
 
 resource_request:
-	#echo('*** resource_request: ', &request, ' ', &manager_id)
+	echo('*** resource_request: ', &request, ' ', &manager_id)
 	$audio_resource_owner:previous = $resource_owner[resource:audio_playback]:owner
 	$active_audio_manager_id = prolog(get_active_audio_manager_id)
 	$active_audio_manager:previous = $active_audio_manager_id:id


### PR DESCRIPTION
This reverts commit 2a39afc295114f8ac7b9385f925594055eeaf031.

Looking at the prolog side, request variable is used when
constructing the resource sets. My guess is dres is cleaning
the variable unless the variable is referenced inside dres
side, and then prolog side doesn't see the variable and dies.
So this log line needs to exist for the whole to work.
