### PR TITLE
Do not release player class when ringtone appears.

### DIFF
--- a/basic/policy/policy.dres
+++ b/basic/policy/policy.dres
@@ -422,7 +422,9 @@ resource_request:
 	if $active_audio_manager:previous != 0 &&                           \
 	   $active_audio_manager:current != 0 &&                            \
 	   $audio_resource_owner:previous != 'call' &&                      \
+	   $audio_resource_owner:previous != 'ringtone' &&                  \
 	   $audio_resource_owner:current != 'call' &&                       \
+	   $audio_resource_owner:current != 'ringtone' &&                   \
 	   $active_audio_manager:previous != $active_audio_manager:current  \
 	   then
 	    #echo('*** force_resource_release_one ', $active_audio_manager:previous)


### PR DESCRIPTION
Call related releasing should be considered when an actual call has been
established (call class acquires resources). Resource request related
force releasing is intended for cases where same level class acquires
the resources, so that other resource client won't keep pending for the
resource.
